### PR TITLE
Supports Google App Engine SDK 1.9.17

### DIFF
--- a/pytest_gae.py
+++ b/pytest_gae.py
@@ -37,51 +37,6 @@ def pytest_configure(config):
     _validate_project_path(config.option.gae_prj_path)
 
 
-def pytest_runtest_setup(item):
-    if not item.config.option.use_gae:
-        return
-
-    gae_path = item.config.option.gae_path
-    project_path = item.config.option.gae_prj_path
-
-    if item.config.option.use_devappserver2:
-        from google.appengine.tools.devappserver2.python import request_handler
-        from google.appengine.tools.devappserver2.python import runtime
-        config = runtime.runtime_config_pb2.Config()
-        runtime.setup_stubs(config)
-        _application = request_handler.RequestHandler(config)
-    else:
-        from google.appengine.tools import old_dev_appserver
-        from google.appengine.tools.dev_appserver_main import DEFAULT_ARGS
-
-        config = DEFAULT_ARGS.copy()
-        config.update({'template_dir': os.path.join(gae_path, 'templates'),
-                       'blobstore_path': '/tmp/dev_appserver.test_blobstore',
-                       'root_path': project_path,
-                       'history_path': '/tmp/dev_appserver.datastore.test_history',
-                       'datastore_path': '/tmp/dev_appserver.test_datastore',
-                       'matcher_path': '/tmp/dev_appserver.test_matcher',
-                       'clear_datastore': True})
-
-        app_cfg, _junk, _from_cache = old_dev_appserver.LoadAppConfig(project_path, {})
-        old_dev_appserver.SetupStubs(app_cfg.application, **config)
-
-
-def pytest_runtest_teardown(item):
-    # There is some problems with GAE and
-    # py.test miscomunication that causes
-    # closed stream handler to be flushed.
-    #
-    # Wich of course causes Exception and
-    # some nasty errors at the end of testing.
-    #
-    # This nasty hack prevents that error to be
-    # displayed.
-    for h in logging.getLogger().handlers:
-        if isinstance(h, logging.StreamHandler):
-            _attach_save_flush(h)
-
-
 def _add_gae_to_syspath(config):
     """ Adds Google App Engine and libs that comes with GAE to sys.path
 
@@ -118,11 +73,3 @@ def _validate_project_path(path):
         raise pytest.UsageError("Your AppEngine's project can not "
                                 "be found. Try to use --gae-project-path "
                                 "option. Current path: <%s>" % path)
-
-
-def _attach_save_flush(handler):
-    def save_flush():
-        if not handler.stream.closed:
-            handler.stream.flush()
-
-    handler.flush = save_flush

--- a/pytest_gae.py
+++ b/pytest_gae.py
@@ -45,10 +45,11 @@ def pytest_runtest_setup(item):
     project_path = item.config.option.gae_prj_path
 
     if item.config.option.use_devappserver2:
+        from google.appengine.tools.devappserver2.python import request_handler
         from google.appengine.tools.devappserver2.python import runtime
         config = runtime.runtime_config_pb2.Config()
         runtime.setup_stubs(config)
-        _application = runtime.PythonRuntime(config)
+        _application = request_handler.RequestHandler(config)
     else:
         from google.appengine.tools import old_dev_appserver
         from google.appengine.tools.dev_appserver_main import DEFAULT_ARGS

--- a/pytest_gae.py
+++ b/pytest_gae.py
@@ -22,8 +22,6 @@ def pytest_addoption(parser):
     group.addoption('--gae-project-path', action='store', dest='gae_prj_path',
                     metavar='PATH', default='./',
                     help="Your project's source code's PATH")
-    group.addoption('--use-devappserver2', action='store_true', dest='use_devappserver2',
-                    default=False, help='Use devappserver2')
 
 
 def pytest_configure(config):
@@ -46,10 +44,7 @@ def _add_gae_to_syspath(config):
 
     sys.path.insert(0, config.option.gae_path)
 
-    if config.option.use_devappserver2:
-        import devappserver2 as dev_appserver
-    else:
-        import dev_appserver
+    import dev_appserver
     dev_appserver.fix_sys_path()
 
 


### PR DESCRIPTION
Removed `old_dev_appserver.py` from Google App Engine SDK 1.9.17.
So, It is need to migrate to new `dev_appserver.py` (a.k.a. devappserver2).

https://code.google.com/p/googleappengine/wiki/SdkReleaseNotes#Version_1.9.17_-_December_9,_2014

> The old development appserver (old_dev_appserver.py) has been removed from the SDK. However, old SDKs that contain old_dev_appserver.py will continue to be available.
